### PR TITLE
remove trailing "%"

### DIFF
--- a/frontmatter/epigraph2.tex
+++ b/frontmatter/epigraph2.tex
@@ -4,7 +4,7 @@
 \if@twoside
 \if@openright
 \null
-\thispagestyle{empty}%
+\thispagestyle{empty}
 \newpage
 \fi
 \fi


### PR DESCRIPTION
This patch removes an excessive "%" sign which resulted in a latex-online compilation failure. See aslushnikov/latex-online#23